### PR TITLE
Feature for passing arguments with command added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ obj/
 /packages/
 riderModule.iml
 .idea/
+.vs/
 /_ReSharper.Caches/

--- a/AiTester.Client/Runner/SingleTestExecutor.cs
+++ b/AiTester.Client/Runner/SingleTestExecutor.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Diagnostics;
-    using System.IO;
+    using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
     using NLog;
@@ -28,7 +28,8 @@
             Process process;
             try
             {
-                process = Process.Start(command);
+                string[] args = command.Split(" ");
+                process = Process.Start(args.First(), args.Skip(1));
                 if (process == null)
                 {
                     return SingleTestResult.FromError($"Can not start process, please check argument:\n {command}");


### PR DESCRIPTION
It is not possible to pass arguments with application start-up command:
```
Quoridor.AiTester.exe --comand "path\to\project\filename.exe --flag" # throws error
Quoridor.AiTester.exe --comand path\to\project\filename.exe # works fine
```

I've implemented this feature and updated `.gitignore` with Visual Studio configuration folder `.vs/`.

P.S. `using System.IO` was useless, so I've removed it.