### PR TITLE
Fix SingleTestExecutor: set process working directory

### DIFF
--- a/AiTester.Client/Runner/SingleTestExecutor.cs
+++ b/AiTester.Client/Runner/SingleTestExecutor.cs
@@ -35,6 +35,7 @@
                     return SingleTestResult.FromError($"Can not start process, please check argument:\n {command}");
                 }
 
+                process.StartInfo.WorkingDirectory = Directory.GetParent(args.First()).FullName;
                 process.StartInfo.RedirectStandardOutput = true;
                 process.StartInfo.RedirectStandardError = true;
                 process.StartInfo.RedirectStandardInput = true;


### PR DESCRIPTION
Set working directory to that where executable is located.